### PR TITLE
Update Selenium to version 3.141.59 and some clean ups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,9 +27,10 @@ crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1")
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.0",
-  "org.seleniumhq.selenium" % "selenium-java" % "2.45.0", 
-  "org.eclipse.jetty" % "jetty-server" % "9.4.12.v20180830" % "test",
-  "org.eclipse.jetty" % "jetty-webapp" % "9.4.12.v20180830" % "test"
+  "org.seleniumhq.selenium" % "selenium-java" % "3.141.59",
+  "org.seleniumhq.selenium" % "htmlunit-driver" % "2.36.0",
+  "org.eclipse.jetty" % "jetty-server" % "9.4.12.v20180830" % Test,
+  "org.eclipse.jetty" % "jetty-webapp" % "9.4.12.v20180830" % Test
 )
 
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ developers := List(
   )
 )
 
+scalaVersion := "2.13.1"
 crossScalaVersions := List("2.10.7", "2.11.12", "2.12.10", "2.13.1")
 
 libraryDependencies ++= Seq(
@@ -65,7 +66,7 @@ OsgiKeys.exportPackage := Seq(
 
 OsgiKeys.importPackage := Seq(
   "org.scalatest.*",
-  "org.scalactic.*", 
+  "org.scalactic.*",
   "scala.*;version=\"$<range;[==,=+);$<replace;"+scalaBinaryVersion.value+";-;.>>\"",
   "*;resolution:=optional"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -93,3 +93,13 @@ credentials += Credentials(Path.userHome / ".ivy2" / ".credentials")
 pgpSecretRing := file((Path.userHome / ".gnupg" / "secring.gpg").getAbsolutePath)
 
 pgpPassphrase := None
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "utf-8",
+  "-explaintypes",
+  "-feature",
+  "-unchecked",
+  "-Ywarn-dead-code",
+  "-Ywarn-unused",
+)

--- a/src/main/scala/org/scalatestplus/selenium/ScreenshotCapturer.scala
+++ b/src/main/scala/org/scalatestplus/selenium/ScreenshotCapturer.scala
@@ -24,5 +24,5 @@ private[selenium] trait ScreenshotCapturer {
   /**
    * Captures a screenshot and saves it as a file in the specified directory.
    */
-  def captureScreenshot(directory: String)
+  def captureScreenshot(directory: String): Unit
 }

--- a/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
@@ -46,6 +46,7 @@ import org.openqa.selenium.JavascriptExecutor
 import org.scalatest.time.Nanosecond
 import org.scalatest.Resources
 import org.scalactic.source
+import org.openqa.selenium.firefox.FirefoxOptions
 
 /**
  * Trait that provides a domain specific language (DSL) for writing browser-based tests using <a href="http://seleniumhq.org">Selenium</a>.  
@@ -4630,14 +4631,25 @@ object HtmlUnit extends HtmlUnit
 trait Firefox extends WebBrowser with Driver with ScreenshotCapturer {
 
   /**
-   * The <code>FirefoxProfile</code> passed to the constructor of the <code>FirefoxDriver</code> returned by <code>webDriver</code>.
+   * The <code>FirefoxProfile</code> seet into <code>FirefoxOptions</code> returned by <code>firefoxOptions</code>.
    *
    * <p>
-   * The <code>FirefoxDriver</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
+   * The <code>FirefoxOptions</code> uses the <code>FirefoxProfile</code> defined as <code>firefoxProfile</code>. By default this is just a <code>new FirefoxProfile</code>.
    * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
    * </p>
    */
+  @deprecated("Use firefoxOptions instead", "3.1.0")
   val firefoxProfile = new FirefoxProfile()
+
+  /**
+   * The <code>FirefoxOptions</code> passed to the constructor of the <code>FirefoxDriver</code> returned by <code>webDriver</code>.
+   *
+   * <p>
+   * The <code>FirefoxDriver</code> uses the <code>FirefoxOptions</code> defined as <code>firefoxOptions</code>. By default this is just a <code>new FirefoxOptions</code>.
+   * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
+   * </p>
+   */
+  val firefoxOptions = new FirefoxOptions().setProfile(firefoxProfile)
 
   /**
    * <code>WebBrowser</code> subtrait that defines an implicit <code>WebDriver</code> for Firefox (an <code>org.openqa.selenium.firefox.FirefoxDriver</code>), with a default
@@ -4648,7 +4660,7 @@ trait Firefox extends WebBrowser with Driver with ScreenshotCapturer {
    * You can mutate this object to modify the profile, or override <code>firefoxProfile</code>.
    * </p>
    */
-  implicit val webDriver: WebDriver = new FirefoxDriver(firefoxProfile)
+  implicit val webDriver: WebDriver = new FirefoxDriver(firefoxOptions)
 
   /**
    * Captures a screenshot and saves it as a file in the specified directory.

--- a/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
+++ b/src/main/scala/org/scalatestplus/selenium/WebBrowser.scala
@@ -25,13 +25,11 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import java.util.concurrent.TimeUnit
 
-import scala.collection.mutable.Buffer
 import scala.collection.JavaConverters._
 import org.openqa.selenium.Cookie
 import java.util.Date
 
 import org.scalatest.time.Span
-import org.scalatest.time.Milliseconds
 import org.openqa.selenium.TakesScreenshot
 import org.openqa.selenium.OutputType
 import java.io.File
@@ -43,10 +41,9 @@ import org.openqa.selenium.support.ui.Select
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.exceptions.StackDepthException
 import org.openqa.selenium.JavascriptExecutor
-import org.scalatest.time.Nanosecond
-import org.scalatest.Resources
 import org.scalactic.source
 import org.openqa.selenium.firefox.FirefoxOptions
+import java.io.Closeable
 
 /**
  * Trait that provides a domain specific language (DSL) for writing browser-based tests using <a href="http://seleniumhq.org">Selenium</a>.  
@@ -1578,7 +1575,7 @@ trait WebBrowser {
         case e: org.openqa.selenium.NoSuchFrameException => 
           throw new TestFailedException(
                      (_: StackDepthException) => Some("Frame at index '" + index + "' not found."),
-                     None,
+                     Option(e),
                      pos
                    )
       }
@@ -1612,7 +1609,7 @@ trait WebBrowser {
         case e: org.openqa.selenium.NoSuchFrameException =>
           throw new TestFailedException(
                      (_: StackDepthException) => Some("Frame with name or ID '" + nameOrId + "' not found."),
-                     None,
+                     Option(e),
                      pos
                    )
       }
@@ -1637,7 +1634,7 @@ trait WebBrowser {
         case e: org.openqa.selenium.NoSuchFrameException => 
           throw new TestFailedException(
                      (_: StackDepthException) => Some("Frame element '" + webElement + "' not found."),
-                     None,
+                     Option(e),
                      pos
                    )
       }
@@ -1662,7 +1659,7 @@ trait WebBrowser {
         case e: org.openqa.selenium.NoSuchFrameException => 
           throw new TestFailedException(
                      (_: StackDepthException) => Some("Frame element '" + element + "' not found."),
-                     None,
+                     Option(e),
                      pos
                    )
       }
@@ -1696,7 +1693,7 @@ trait WebBrowser {
         case e: org.openqa.selenium.NoSuchWindowException => 
           throw new TestFailedException(
                      (_: StackDepthException) => Some("Window with nameOrHandle '" + nameOrHandle + "' not found."),
-                     None,
+                     Option(e),
                      pos
                    )
       }
@@ -2850,7 +2847,7 @@ trait WebBrowser {
         Some(createTypedElement(driver.findElement(by), pos))
       }
       catch {
-        case e: org.openqa.selenium.NoSuchElementException => None
+        case _: org.openqa.selenium.NoSuchElementException => None
       }
 
     /**
@@ -4300,6 +4297,22 @@ trait WebBrowser {
    * </pre>
    */
   object capture {
+
+    private def copy(source: File, destination: File): Unit = {
+
+      def close(closeable: Closeable): Unit = if (closeable != null) closeable.close()
+
+      var outStream: FileOutputStream = null
+      var inputStream: FileInputStream = null
+      try {
+        inputStream = new FileInputStream(source)
+        outStream = new FileOutputStream(destination)
+        outStream.getChannel().transferFrom(inputStream.getChannel(), 0, Long.MaxValue)
+      } finally {
+        close(inputStream)
+        close(outStream)
+      }
+    }
     
     /**
      * Capture screenshot and save it as the specified name (if file name does not end with .png, it will be extended automatically) in capture directory, 
@@ -4312,8 +4325,7 @@ trait WebBrowser {
         case takesScreenshot: TakesScreenshot => 
           val tmpFile = takesScreenshot.getScreenshotAs(OutputType.FILE)
           val outFile = new File(targetDir, if (fileName.toLowerCase.endsWith(".png")) fileName else fileName + ".png")
-          new FileOutputStream(outFile).getChannel.transferFrom(
-            new FileInputStream(tmpFile).getChannel, 0, Long.MaxValue)
+          copy(tmpFile, outFile)
         case _ =>
           throw new UnsupportedOperationException("Screen capture is not support by " + driver.getClass.getName)
       }
@@ -4329,11 +4341,9 @@ trait WebBrowser {
         case takesScreenshot: TakesScreenshot =>
           val tmpFile = takesScreenshot.getScreenshotAs(OutputType.FILE)
           val dir = new File(dirName)
-          if (!dir.exists)
-            dir.mkdirs()
+          if (!dir.exists) dir.mkdirs()
           val outFile = new File(dir, if (tmpFile.getName.toLowerCase.endsWith(".png")) "ScalaTest-" + tmpFile.getName else "ScalaTest-" + tmpFile.getName + ".png")
-          new FileOutputStream(outFile).getChannel.transferFrom(
-            new FileInputStream(tmpFile).getChannel, 0, Long.MaxValue)
+          copy(tmpFile, outFile)
         case _ =>
           throw new UnsupportedOperationException("Screen capture is not support by " + driver.getClass.getName)
       }
@@ -4349,8 +4359,7 @@ trait WebBrowser {
           val tmpFile = takesScreenshot.getScreenshotAs(OutputType.FILE)
           val fileName = tmpFile.getName
           val outFile = new File(targetDir, if (fileName.toLowerCase.endsWith(".png")) fileName else fileName + ".png")
-          new FileOutputStream(outFile).getChannel.transferFrom(
-            new FileInputStream(tmpFile).getChannel, 0, Long.MaxValue)
+          copy(tmpFile, outFile)
           outFile
         case _ =>
           throw new UnsupportedOperationException("Screen capture is not support by " + driver.getClass.getName)

--- a/src/test/scala/org/scalatestplus/selenium/DriverSpec.scala
+++ b/src/test/scala/org/scalatestplus/selenium/DriverSpec.scala
@@ -2,7 +2,7 @@ package org.scalatestplus.selenium
 
 import org.scalatest._
 import SharedHelpers.EventRecordingReporter
-import org.openqa.selenium.firefox.{FirefoxDriver, FirefoxProfile}
+import org.openqa.selenium.firefox.{FirefoxDriver, FirefoxOptions}
 import org.openqa.selenium.safari.SafariDriver
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.ie.InternetExplorerDriver
@@ -60,7 +60,7 @@ class DriverSpec extends funspec.AnyFunSpec {
 
     it("should work with Firefox", Slow) {
       // Cancel when Firefox is not available
-      try new FirefoxDriver(new FirefoxProfile) catch { case e: Throwable => cancel(e) }
+      try new FirefoxDriver(new FirefoxOptions) catch { case e: Throwable => cancel(e) }
       val s = new GoogleSearchSpecWithFirefox
       val rep = new EventRecordingReporter
       s.run(None, Args(reporter = rep))

--- a/src/test/scala/org/scalatestplus/selenium/DriverSpec.scala
+++ b/src/test/scala/org/scalatestplus/selenium/DriverSpec.scala
@@ -34,8 +34,6 @@ class DriverSpec extends funspec.AnyFunSpec {
     }
 
     class GoogleSearchSpecWithChrome extends GoogleSearchSpec with Chrome
-    class GoogleSearchSpecWithSafari extends GoogleSearchSpec with Safari
-    class GoogleSearchSpecWithInternetExplorer extends GoogleSearchSpec with InternetExplorer
     class GoogleSearchSpecWithFirefox extends GoogleSearchSpec with Firefox
 
     it("should work with Chrome", Slow) {

--- a/src/test/scala/org/scalatestplus/selenium/ScreenshotSpec.scala
+++ b/src/test/scala/org/scalatestplus/selenium/ScreenshotSpec.scala
@@ -17,9 +17,6 @@ package org.scalatestplus.selenium
 
 import org.scalatest._
 import org.scalatest.time.SpanSugar
-import java.io.File
-import org.scalatest.Args
-import org.scalatestplus.selenium.SharedHelpers.SilentReporter
 import org.scalatest.Ignore
 import org.scalatest.matchers.should.Matchers
 

--- a/src/test/scala/org/scalatestplus/selenium/SharedHelpers.scala
+++ b/src/test/scala/org/scalatestplus/selenium/SharedHelpers.scala
@@ -17,16 +17,6 @@ package org.scalatestplus.selenium
 
 import org.scalatest.{Assertions, Reporter}
 import org.scalatest.events._
-import java.io.File
-import org.scalatest.exceptions.StackDepthException
-import scala.annotation.tailrec
-import scala.collection.GenMap
-import scala.collection.GenTraversable
-import scala.collection.SortedMap
-import scala.collection.SortedSet
-import java.util.concurrent.Executors
-import org.scalactic.Prettifier
-import org.scalactic.ArrayHelper.deep
 
 object SharedHelpers extends Assertions {
 
@@ -42,7 +32,7 @@ object SharedHelpers extends Assertions {
     def testSucceededEventsReceived: List[TestSucceeded] = {
       synchronized {
         eventsReceived filter {
-          case event: TestSucceeded => true
+          case _: TestSucceeded => true
           case _ => false
         } map {
           case event: TestSucceeded => event
@@ -53,7 +43,7 @@ object SharedHelpers extends Assertions {
     def testStartingEventsReceived: List[TestStarting] = {
       synchronized {
         eventsReceived filter {
-          case event: TestStarting => true
+          case _: TestStarting => true
           case _ => false
         } map {
           case event: TestStarting => event
@@ -66,7 +56,7 @@ object SharedHelpers extends Assertions {
     def infoProvidedEventsReceived: List[InfoProvided] = {
       synchronized {
         eventsReceived filter {
-          case event: InfoProvided => true
+          case _: InfoProvided => true
           case _ => false
         } map {
           case event: InfoProvided => event
@@ -77,7 +67,7 @@ object SharedHelpers extends Assertions {
     def noteProvidedEventsReceived: List[NoteProvided] = {
       synchronized {
         eventsReceived filter {
-          case event: NoteProvided => true
+          case _: NoteProvided => true
           case _ => false
         } map {
           case event: NoteProvided => event
@@ -88,7 +78,7 @@ object SharedHelpers extends Assertions {
     def alertProvidedEventsReceived: List[AlertProvided] = {
       synchronized {
         eventsReceived filter {
-          case event: AlertProvided => true
+          case _: AlertProvided => true
           case _ => false
         } map {
           case event: AlertProvided => event
@@ -99,7 +89,7 @@ object SharedHelpers extends Assertions {
     def markupProvidedEventsReceived: List[MarkupProvided] = {
       synchronized {
         eventsReceived filter {
-          case event: MarkupProvided => true
+          case _: MarkupProvided => true
           case _ => false
         } map {
           case event: MarkupProvided => event
@@ -110,7 +100,7 @@ object SharedHelpers extends Assertions {
     def scopeOpenedEventsReceived: List[ScopeOpened] = {
       synchronized {
         eventsReceived filter {
-          case event: ScopeOpened => true
+          case _: ScopeOpened => true
           case _ => false
         } map {
           case event: ScopeOpened => event
@@ -121,7 +111,7 @@ object SharedHelpers extends Assertions {
     def scopeClosedEventsReceived: List[ScopeClosed] = {
       synchronized {
         eventsReceived filter {
-          case event: ScopeClosed => true
+          case _: ScopeClosed => true
           case _ => false
         } map {
           case event: ScopeClosed => event
@@ -132,7 +122,7 @@ object SharedHelpers extends Assertions {
     def scopePendingEventsReceived: List[ScopePending] = {
       synchronized {
         eventsReceived filter {
-          case event: ScopePending => true
+          case _: ScopePending => true
           case _ => false
         } map {
           case event: ScopePending => event
@@ -143,7 +133,7 @@ object SharedHelpers extends Assertions {
     def testPendingEventsReceived: List[TestPending] = {
       synchronized {
         eventsReceived filter {
-          case event: TestPending => true
+          case _: TestPending => true
           case _ => false
         } map {
           case event: TestPending => event
@@ -154,7 +144,7 @@ object SharedHelpers extends Assertions {
     def testCanceledEventsReceived: List[TestCanceled] = {
       synchronized {
         eventsReceived filter {
-          case event: TestCanceled => true
+          case _: TestCanceled => true
           case _ => false
         } map {
           case event: TestCanceled => event
@@ -165,7 +155,7 @@ object SharedHelpers extends Assertions {
     def testFailedEventsReceived: List[TestFailed] = {
       synchronized {
         eventsReceived filter {
-          case event: TestFailed => true
+          case _: TestFailed => true
           case _ => false
         } map {
           case event: TestFailed => event
@@ -176,7 +166,7 @@ object SharedHelpers extends Assertions {
     def testIgnoredEventsReceived: List[TestIgnored] = {
       synchronized {
         eventsReceived filter {
-          case event: TestIgnored => true
+          case _: TestIgnored => true
           case _ => false
         } map {
           case event: TestIgnored => event
@@ -187,7 +177,7 @@ object SharedHelpers extends Assertions {
     def suiteStartingEventsReceived: List[SuiteStarting] = {
       synchronized {
         eventsReceived filter {
-          case event: SuiteStarting => true
+          case _: SuiteStarting => true
           case _ => false
         } map {
           case event: SuiteStarting => event
@@ -198,7 +188,7 @@ object SharedHelpers extends Assertions {
     def suiteCompletedEventsReceived: List[SuiteCompleted] = {
       synchronized {
         eventsReceived filter {
-          case event: SuiteCompleted => true
+          case _: SuiteCompleted => true
           case _ => false
         } map {
           case event: SuiteCompleted => event
@@ -209,7 +199,7 @@ object SharedHelpers extends Assertions {
     def suiteAbortedEventsReceived: List[SuiteAborted] = {
       synchronized {
         eventsReceived filter {
-          case event: SuiteAborted => true
+          case _: SuiteAborted => true
           case _ => false
         } map {
           case event: SuiteAborted => event

--- a/src/test/scala/org/scalatestplus/selenium/WebBrowserSpec.scala
+++ b/src/test/scala/org/scalatestplus/selenium/WebBrowserSpec.scala
@@ -22,7 +22,6 @@ import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.firefox.FirefoxDriver
-import org.openqa.selenium.firefox.FirefoxProfile
 import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.openqa.selenium.ie.InternetExplorerDriver
 import org.openqa.selenium.safari.SafariDriver
@@ -36,6 +35,7 @@ import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar
 import scala.reflect.ClassTag
 import org.scalactic.source.Position.here
+import org.openqa.selenium.firefox.FirefoxOptions
 
 trait InputFieldBehaviour extends JettySpec with matchers.should.Matchers with SpanSugar with WebBrowser with HtmlUnit {
   def inputField[T <: ValueElement](file: String, fn: (String) => T, typeDescription: String, description: String, value1: String, value2: String, lineNumber: Int): Unit = {
@@ -1344,7 +1344,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
      */
     ignore("isScreenshotSupported should return true for FirefoxDriver") {
       val driver = try {
-        new FirefoxDriver(new FirefoxProfile())
+        new FirefoxDriver(new FirefoxOptions())
       }
       catch { case e: Throwable => cancel(e) }
       try isScreenshotSupported(driver) should be (true)

--- a/src/test/scala/org/scalatestplus/selenium/WebBrowserSpec.scala
+++ b/src/test/scala/org/scalatestplus/selenium/WebBrowserSpec.scala
@@ -16,9 +16,7 @@
 package org.scalatestplus.selenium
 
 import java.io.File
-import java.util.concurrent.TimeUnit
 import org.openqa.selenium.Cookie
-import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.firefox.FirefoxDriver
@@ -26,8 +24,6 @@ import org.openqa.selenium.htmlunit.HtmlUnitDriver
 import org.openqa.selenium.ie.InternetExplorerDriver
 import org.openqa.selenium.safari.SafariDriver
 import org.scalatest._
-import SharedHelpers.SilentReporter
-import org.scalatest.Suite
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.tagobjects.Slow
 import org.scalatest.time.Seconds
@@ -289,12 +285,12 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
     it("should, when a valid text area is found, return a TextArea instance") {
       go to (host + "find-textarea.html")
       val textarea1 = textArea("textarea1")
-      textarea1.text should be ("value1")
+      textarea1.text.trim should be ("value1")
     }
     it("should, when multiple matching text areas exist, return the first one") {
       go to (host + "find-textarea.html")
       val text2 = textArea("textarea2")
-      text2.text should be ("value2")
+      text2.text.trim should be ("value2")
     }
   }
 
@@ -541,14 +537,14 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
 
   describe("goBack") {
     it("should have no effect if already at oldest page") {
-      for (i <- 0 to 1000)
+      for (_ <- 0 to 1000)
         goBack()
     }
   }
 
   describe("goForward") {
     it("should have no effect if already at newest page") {
-      for (i <- 0 to 1000)
+      for (_ <- 0 to 1000)
         goForward()
     }
   }
@@ -582,7 +578,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       go to (host + "find-textarea.html")
       find("textarea1") match {
         case Some(textArea: TextArea) =>
-          textArea.text should be ("value1")
+          textArea.text.trim should be ("value1")
         case other => 
           fail("Expected Some(textArea: TextArea), but got: " + other)
       }
@@ -680,7 +676,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       textarea1.hasNext should be (true)
       textarea1.next match {
         case textArea: TextArea =>
-          textArea.text should be ("value1")
+          textArea.text.trim should be ("value1")
         case other =>
           fail("Expected TextArea, but got: " + other)
       }
@@ -1037,7 +1033,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       go to (host + "textarea.html")
       pageTitle should be ("Text Area")
       
-      textArea("area1").value should be ("")
+      textArea("area1").value.trim should be ("")
 
       click on "area1"
       enter("area 1 - line 1\narea 1 - line 2")
@@ -1527,7 +1523,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid id") {
         go to (host + "click.html")
         id("aLink").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1579,7 +1575,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid name") {
         go to (host + "click.html")
         name("aLinkName").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1631,7 +1627,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid xpath") {
         go to (host + "click.html")
         xpath("//html/body/a").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1683,7 +1679,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid className") {
         go to (host + "click.html")
         className("aClass").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1735,7 +1731,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid cssSelector") {
         go to (host + "click.html")
         cssSelector("a[id='aLink']").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1787,7 +1783,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid linkText") {
         go to (host + "click.html")
         linkText("Test Click").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1839,7 +1835,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid partialLinkText") {
         go to (host + "click.html")
         partialLinkText("Click").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1891,7 +1887,7 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       it("should return Some(Element) when findElement method is called with valid tagname") {
         go to (host + "click.html")
         tagName("a").findElement match {
-          case Some(element: Element) => // ok
+          case Some(_: Element) => // ok
           case other => fail("Expected Some(element: Element), but got: " + other)
         }
       }
@@ -1988,11 +1984,11 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
       val examples: TableFor1[WebBrowser with Driver] = {
         val availableDrivers: List[WebBrowser with Driver] =
         List(
-          try List(Chrome) catch { case e: Throwable => List.empty[WebBrowser with Driver] },
-          try List(Firefox) catch { case e: Throwable => List.empty[WebBrowser with Driver] },
+          try List(Chrome) catch { case _: Throwable => List.empty[WebBrowser with Driver] },
+          try List(Firefox) catch { case _: Throwable => List.empty[WebBrowser with Driver] },
           List(HtmlUnit),
-          try List(InternetExplorer) catch { case e: Throwable => List.empty[WebBrowser with Driver] },
-          try List(Safari) catch { case e: Throwable => List.empty[WebBrowser with Driver] }
+          try List(InternetExplorer) catch { case _: Throwable => List.empty[WebBrowser with Driver] },
+          try List(Safari) catch { case _: Throwable => List.empty[WebBrowser with Driver] }
         ).flatten
         Table("web browser", availableDrivers: _*)
       }
@@ -2001,7 +1997,6 @@ class WebBrowserSpec extends JettySpec with matchers.should.Matchers with SpanSu
   }
   describe("Page trait") {
     it("should be independent from WebBrowser trait") {
-      val code =
       """
       class HomePage extends Page {
         val url = "localhost:9000/index.html"


### PR DESCRIPTION
I'm unsure which branch I should target here, but my idea is to make this part of the release compatible with 3.1.0. This should be part of updating ScalaTest+Play to use Scalatest 3.1.0.